### PR TITLE
Update runtime to 5.15-21.08

### DIFF
--- a/com.gitlab.ColinDuquesnoy.MellowPlayer.yml
+++ b/com.gitlab.ColinDuquesnoy.MellowPlayer.yml
@@ -1,8 +1,8 @@
 app-id: com.gitlab.ColinDuquesnoy.MellowPlayer
 runtime: org.kde.Platform
-runtime-version:  "5.15"
+runtime-version:  "5.15-21.08"
 base: io.qt.qtwebengine.BaseApp
-base-version: "5.15"
+base-version: "5.15-21.08"
 sdk: org.kde.Sdk
 command: MellowPlayer
 finish-args:


### PR DESCRIPTION
The 5.15 version of the KDE Runtime is based on the 20.08 version of the Freedesktop Runtime and will stay as-is to keep compatibility.
The 5.15-21.08 version of the KDE Runtime is based on the 21.08 Freedesktop one. The Qt/KDE Libraries are mostyl similar between the two runtimes.

This change is mostly maintenance to keep the base runtime updated.