### PR TITLE
Drop org.kde.* own-name

### DIFF
--- a/com.gitlab.ColinDuquesnoy.MellowPlayer.yml
+++ b/com.gitlab.ColinDuquesnoy.MellowPlayer.yml
@@ -16,7 +16,6 @@ finish-args:
   - --own-name=org.mpris.MediaPlayer2.MellowPlayer3.*
   - --env=TMPDIR=/var/tmp
   - --talk-name=org.kde.StatusNotifierWatcher
-  - --own-name=org.kde.*
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.freedesktop.PowerManagement
   - --talk-name=org.gnome.SessionManager


### PR DESCRIPTION
This is no longer required with any supported runtimes, the issue was fixed in Qt

https://docs.flatpak.org/en/latest/desktop-integration.html#statusnotifier

> Most implementations of StatusNotifer have dropped this requirement

https://github.com/flathub/flatpak-builder-lint/issues/ 66#issuecomment-1386033025